### PR TITLE
Add Open Sauce agenda page with retro style

### DIFF
--- a/schedule.html
+++ b/schedule.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Open Sauce 2025 Agenda</title>
+<style>
+body {
+  background-color: #000;
+  color: #0f0;
+  font-family: "Courier New", monospace;
+}
+h1, h2 {
+  text-align: center;
+}
+.agenda {
+  width: 80%;
+  margin: auto;
+  border-collapse: collapse;
+}
+.agenda th, .agenda td {
+  border: 1px solid #0f0;
+  padding: 8px;
+}
+.agenda th {
+  background-color: #222;
+}
+</style>
+</head>
+<body>
+<h1>Open Sauce 2025</h1>
+<h2>A Celebration of Makers and Creators</h2>
+<table class="agenda">
+<thead>
+<tr><th>Day</th><th>Time</th><th>Event</th><th>Location</th></tr>
+</thead>
+<tbody>
+<tr><td rowspan="3">Friday, July 18 (Industry Day)</td><td>03:15 PM</td><td>Cosplay: Making From Pop Culture</td><td>Second Stage</td></tr>
+<tr><td>03:45 PM</td><td>Pitching Your Game to Publishers</td><td>Outdoor Stage</td></tr>
+<tr><td>03:45 PM</td><td>Space (intentionally left blank)</td><td>Main Stage</td></tr>
+<tr><td rowspan="5">Saturday, July 19 (Day 1)</td><td>04:00 PM</td><td>Narrative-first YouTube Channel</td><td>Second Stage</td></tr>
+<tr><td>04:15 PM</td><td>Deep Dives: The Art of Saying More</td><td>Main Stage</td></tr>
+<tr><td>04:30 PM</td><td>You Don't Need to Crunch</td><td>Second Stage</td></tr>
+<tr><td>04:45 PM</td><td>Man vs. Machining</td><td>Outdoor Stage</td></tr>
+<tr><td>05:00 PM</td><td>Voyagers of Nera Developers</td><td>Second Stage</td></tr>
+<tr><td rowspan="1">Sunday, July 20 (Day 2)</td><td>05:15 PM</td><td>Scare The Coyote: LIVE!</td><td>Main Stage</td></tr>
+</tbody>
+</table>
+<p style="text-align:center;">Data extracted from <a href="https://opensauce.com/agenda/">opensauce.com</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `schedule.html` with Open Sauce 2025 agenda

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68828ecb92cc832ca260c384062b57d7